### PR TITLE
fix: infinite re-render when switching to advanced expression mode

### DIFF
--- a/console/src/components/rules/rule-conditions-canvas.tsx
+++ b/console/src/components/rules/rule-conditions-canvas.tsx
@@ -136,6 +136,8 @@ interface SegmentOption {
   recordKeyPath?: string;
 }
 
+const EMPTY_EXTERNAL_API_BINDINGS: ExternalApiBinding[] = [];
+
 const CONNECTOR_LABELS: Record<BuilderConnector, string> = {
   and: 'AND',
   or: 'OR',
@@ -207,7 +209,7 @@ export function RuleConditionsCanvas({
   const guidedResult = useMemo(() => serializeConditionTree(builderRoot), [builderRoot]);
   const currentExpression = mode === 'guided' ? guidedResult.expression : advancedExpression;
   const currentSourceBindings = mode === 'guided' ? guidedResult.sourceBindings : manualSourceBindings;
-  const currentExternalApiBindings = mode === 'guided' ? guidedResult.externalApiBindings : [];
+  const currentExternalApiBindings = mode === 'guided' ? guidedResult.externalApiBindings : EMPTY_EXTERNAL_API_BINDINGS;
   const currentMetadata = useMemo(
     () => (mode === 'guided' ? withBuilderMetadata(metadataSeed, builderRoot) : metadataSeed),
     [builderRoot, metadataSeed, mode],


### PR DESCRIPTION
## Summary

- Fixes React error #185 (Maximum update depth exceeded) when switching from expression to advanced mode in the rule editor
- Root cause: inline `[]` literal for `currentExternalApiBindings` created a new array reference every render, causing the `onChange` useEffect to loop infinitely
- Fix: extract to a stable module-level constant `EMPTY_EXTERNAL_API_BINDINGS`

## Test plan

- [x] `pnpm -C console run typecheck` passes
- [x] All 128 console tests pass
- [ ] Manual: edit a rule → switch from expression to advanced mode → no crash